### PR TITLE
Built in commands

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,3 +73,8 @@ required-features = ["tokio/macros"]
 [[example]]
 name = "status"
 required-features = ["tokio/macros"]
+
+[dev-dependencies.tokio]
+version = "0.2.21"
+features = ["macros", "rt-threaded"]
+

--- a/examples/ping_pong.rs
+++ b/examples/ping_pong.rs
@@ -4,7 +4,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     client.on_message_create(|s, msg| async move {
         if msg.content == "!ping" {
-            msg.send_message(&s.http, "!pong").await?;
+            msg.send(&s.http, "!pong").await?;
         }
 
         Ok(())

--- a/src/commands/index.rs
+++ b/src/commands/index.rs
@@ -18,13 +18,15 @@ use super::Command;
 /// use panda::commands::{Command, CommandResult, CommandsIndex};
 /// use panda::models::channel::Message;
 ///
-/// async fn pong(session: Arc<SessionData<()>>, msg: Message) -> CommandResult {
+/// async fn ping(session: Arc<SessionData<()>>, msg: Message) -> CommandResult {
 ///     msg.send(&session.http, "Pong").await?;
 ///     Ok(())
 /// }
 ///
+/// // Defining a `CommandsIndex`. We tell to panda we need a bot using the `?` prefix and a `ping`
+/// // command to run the function `ping`
 /// let mut index = CommandsIndex::new("?");
-/// index.command("ping", Command::new(pong));
+/// index.command("ping", Command::new(ping)).unwrap();
 ///
 /// // The user typed `!ping` (the prefix is wrong)
 /// assert!(index.parse("!ping").is_none());
@@ -35,6 +37,10 @@ use super::Command;
 /// // The user typed `?ping` (good command invocation)
 /// assert!(index.parse("?ping").is_some());
 /// ```
+///
+/// The [module-level documentation] shows how to create a bot using commands
+///
+/// [module-level documentation]: ./index.html
 pub struct CommandsIndex<S> {
     commands: HashMap<String, Command<S>>,
     prefix: String,
@@ -42,7 +48,7 @@ pub struct CommandsIndex<S> {
 
 impl<S> CommandsIndex<S> {
     /// Creates a new [`CommandsIndex`] and sets its prefix (see [module-level
-    /// documentation](../mod.commands.html)
+    /// documentation](./index.html))
     ///
     /// The newly created [`CommandsIndex`] instance is empty, meaning there isn't any command
     /// defined. If you start your bot with an empty [`CommandsIndex`], it won't react to any
@@ -56,11 +62,13 @@ impl<S> CommandsIndex<S> {
         }
     }
 
-    /// Adds a new command to `self`
+    /// Adds a new [`Command`] to `self`
     ///
-    /// The command is identified by the unique name `name` and set up by the argument `command`.
+    /// The [`Command`] is identified by the unique name `name` and set up by the argument `command`.
     /// `name` must not contain whitespaces so this returns the `String` name has been cast into if
     /// a whitespace has been found inside
+    ///
+    /// [`Command`]: ./struct.Command.html
     pub fn command<T: Into<String>>(&mut self, name: T, command: Command<S>) -> Result<(), String> {
         let name = name.into();
         if name.find(char::is_whitespace).is_some() {
@@ -73,7 +81,7 @@ impl<S> CommandsIndex<S> {
 
     /// Parses a command sent by the user. Returns the [`Command`] to call or `None`
     ///
-    /// [`Command`]: ../struct.Command.html
+    /// [`Command`]: ./struct.Command.html
     pub fn parse(&self, command: &str) -> Option<&Command<S>> {
         if !command.starts_with(&self.prefix) {
             // There isn't anything to do

--- a/src/commands/index.rs
+++ b/src/commands/index.rs
@@ -53,11 +53,12 @@ impl<S> CommandsIndex<S> {
         Ok(())
     }
 
+    // pub(crate) required for unit-tests
     /// Parses a command sent by the user. Returns the [`Command`] to call with its arguments or
     /// `None`
     ///
     /// [`Command`]: ./struct.Command.html
-    fn parse(&self, command: &str) -> Option<(&Command<S>, String)> {
+    pub(crate) fn parse(&self, command: &str) -> Option<(&Command<S>, String)> {
         if !command.starts_with(&self.prefix) {
             // There isn't anything to do
             return None;

--- a/src/commands/index.rs
+++ b/src/commands/index.rs
@@ -1,0 +1,46 @@
+//! [`CommandsIndex`] and related utilities
+//!
+//! [`CommandsIndex`]: ./struct.CommandsIndex.html
+
+use std::collections::HashMap;
+
+use super::Command;
+
+/// The handler for all the commands
+pub struct CommandsIndex<S> {
+    commands: HashMap<String, Command<S>>,
+    prefix: String,
+}
+
+impl<S> CommandsIndex<S> {
+    /// Creates a new [`CommandsIndex`] and sets its prefix (see [module-level
+    /// documentation](../mod.commands.html)
+    ///
+    /// The newly created [`CommandsIndex`] instance is empty, meaning there isn't any command
+    /// defined. If you start your bot with an empty [`CommandsIndex`], it won't react to any
+    /// command
+    ///
+    /// [`CommandsIndex`]: ./struct.CommandsIndex.html
+    pub fn new<T: Into<String>>(prefix: T) -> Self {
+        Self {
+            commands: HashMap::new(),
+            prefix: prefix.into(),
+        }
+    }
+
+    /// Adds a new command to `self`
+    ///
+    /// The command is identified by the unique name `name` and set up by the argument `command`.
+    /// `name` must not contain whitespaces so this returns the `String` name has been cast into if
+    /// a whitespace has been found inside
+    pub fn command<T: Into<String>>(&mut self, name: T, command: Command<S>) -> Result<(), String> {
+        let name = name.into();
+        if name.find(char::is_whitespace).is_some() {
+            return Err(name);
+        }
+
+        self.commands.insert(name, command);
+        Ok(())
+    }
+}
+

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,0 +1,55 @@
+//! # Panda Commands
+//!
+//! ## Introduction to commands
+//! The commands API, used to easily create commands for bots. For example, a user could type
+//! ```text
+//! !hello
+//! ```
+//! to send the command `hello` to the bot, and the bot will do the specified work
+//!
+//! ## Syntax
+//! A command is called like this
+//! ```text
+//! <prefix><command> <arguments>
+//! ```
+//! where `<prefix>` is any token, the same for all the commands, and used to recognize the bot
+//! which shall run the given command. Different bots should have different prefixes, and it is
+//! **not** recommended to use the widely used `!` prefix.
+//!
+//! `command` is the name of the command to run.
+//!
+//! `arguments` is some text passed to the command to work on it. Arguments are optional and
+//! separated from `command` by a whitespace.
+
+use std::sync::Arc;
+
+use futures::future::BoxFuture;
+
+use crate::models::channel::Message;
+use crate::Session;
+
+
+/// The built-in command type
+pub struct Command<S> {
+    callback: Box<CommandCallback<S>>,
+}
+
+impl<S> Command<S> {
+    /// Creates a new [`Command`] from a callback
+    ///
+    /// [`Command`]: ./struct.Command.html
+    pub fn new(callback: Box<CommandCallback<S>>) -> Self {
+        Self {
+            callback,
+        }
+    }
+}
+
+/// The type of the callback accepted by [`crate::commands::Command`]
+type CommandCallback<S> = dyn Fn(Arc<Session<S>>, Message) -> BoxFuture<'static, CommandResult> + Send + Sync;
+
+/// The result returned by a [`Command`] when run
+///
+/// [`Command`]: ../commands/struct.Command.html
+pub type CommandResult = Result<(), Box<dyn std::error::Error>>;
+

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -106,3 +106,6 @@ mod index;
 #[doc(inline)]
 pub use index::{CommandsIndex, handle_commands};
 
+#[cfg(test)]
+mod tests;
+

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -22,18 +22,19 @@
 //! separated from `command` by a whitespace.
 //!
 //! # Example
-//! ```
+//! ```rust,should_panic
 //! use std::sync::Arc;
 //!
 //! use panda::client::SessionData;
 //! use panda::commands::{Command, CommandResult, CommandsIndex};
 //! use panda::models::channel::Message;
 //!
-//! async fn pong(session: Arc<SessionData<()>>, msg: Message) -> CommandResult {
+//! async fn ping(session: Arc<SessionData<()>>, msg: Message) -> CommandResult {
 //!     msg.send(&session.http, "Pong").await?;
 //!     Ok(())
 //! }
 //!
+//! /// Handles the MessageCreate event by calling the good command
 //! async fn handler(index: Arc<CommandsIndex<()>>, session: Arc<SessionData<()>>, msg: Message) ->
 //! Result<(), Box<dyn std::error::Error>> {
 //!     let cmd = match index.parse(&msg.content) {
@@ -46,16 +47,23 @@
 //!
 //! #[tokio::main]
 //! async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//!     // We create a new CommandsIndex to tell panda we need a bot using the prefix `?` and the
+//!     // defining the command `ping` which calls the async function `ping`
 //!     let mut index = CommandsIndex::new("?");
-//!     index.command("ping", Command::new(pong));
+//!     index.command("ping", Command::new(ping)).unwrap();
+//!
+//!     // We wrap it in an `Arc` for lifetimes reasons
 //!     let index = Arc::new(index);
 //!
+//!     // And then, we create the bot and an event handler for the event `MessageCreate` which
+//!     // runs the requested commands
 //!     let mut bot = panda::new("your token here").await.unwrap();
 //!     bot.on_message_create(move |session, event| {
 //!         handler(index.clone(), session, event.0)
 //!     });
 //!
-//!     bot.start().await;
+//!     // The last step is to start the newly created bot !
+//!     bot.start().await.unwrap();
 //!
 //!     Ok(())
 //! }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -34,12 +34,28 @@
 //!     Ok(())
 //! }
 //!
+//! async fn handler(index: Arc<CommandsIndex<()>>, session: Arc<SessionData<()>>, msg: Message) ->
+//! Result<(), Box<dyn std::error::Error>> {
+//!     let cmd = match index.parse(&msg.content) {
+//!         Some(val) => val,
+//!         None      => return Ok(()),
+//!     };
+//!
+//!     cmd.run(session, msg).await
+//! }
+//!
 //! #[tokio::main]
 //! async fn main() -> Result<(), Box<dyn std::error::Error>> {
 //!     let mut index = CommandsIndex::new("?");
 //!     index.command("ping", Command::new(pong));
+//!     let index = Arc::new(index);
 //!
-//!     let mut bot = panda::new("your token here");
+//!     let mut bot = panda::new("your token here").await.unwrap();
+//!     bot.on_message_create(move |session, event| {
+//!         handler(index.clone(), session, event.0)
+//!     });
+//!
+//!     bot.start().await;
 //!
 //!     Ok(())
 //! }

--- a/src/commands/tests.rs
+++ b/src/commands/tests.rs
@@ -1,0 +1,81 @@
+use std::sync::Arc;
+
+use crate::client::SessionData;
+use crate::commands::{Command, CommandsIndex, CommandResult};
+use crate::models::channel::Message;
+
+
+async fn hello(_session: Arc<SessionData<()>>, _msg: Message, _args: String) -> CommandResult {
+    println!("Hello");
+    Ok(())
+}
+
+fn empty_index() -> CommandsIndex<()> {
+    CommandsIndex::<()>::new("?")
+}
+
+fn filled_index() -> CommandsIndex<()> {
+    let mut index = empty_index();
+    let hello = Command::new(hello);
+    index.command("hello", hello).unwrap();
+    index
+}
+
+#[test]
+fn commands_index_command_returns_err() {
+    let mut index = empty_index();
+
+    // Error : "hello world" is not a valid name for a command because whitespaces are forbidden
+    let hello = Command::new(hello);
+    assert!(index.command("hello world", hello).is_err());
+}
+
+#[test]
+fn commands_index_command_returns_ok() {
+    let mut index = empty_index();
+
+    // Ok : "hello" is a valid name for a command
+    let hello = Command::new(hello);
+    assert!(index.command("hello", hello).is_ok());
+}
+
+#[test]
+fn commands_index_parse_bad_prefix() {
+    let index = filled_index();
+
+    // Wrong prefix : the user shall write `?hello` instead
+    assert!(index.parse("!hello").is_none());
+}
+
+#[test]
+fn commands_index_parse_bad_command() {
+    let index = filled_index();
+
+    // Wrong command
+    assert!(index.parse("?hell").is_none());
+}
+
+#[test]
+fn commands_index_parse_no_args() {
+    let index = filled_index();
+    let (_command, args) = index.parse("?hello").unwrap();
+
+    assert!(args.is_empty());
+}
+
+#[test]
+fn commands_index_parse_no_args_with_trailing_whitespace() {
+    let index = filled_index();
+    let (_command, args) = index.parse("?hello ").unwrap();
+
+    assert!(args.is_empty());
+}
+
+#[test]
+fn commands_index_parse_with_args() {
+    let index = filled_index();
+    let (_command, args) = index.parse("?hello world").unwrap();
+
+    assert_eq!(args, "world");
+}
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,6 +66,8 @@ define_cfg! {
     #[doc(inline)]
     pub mod client;
     #[doc(inline)]
+    pub mod commands;
+    #[doc(inline)]
     pub mod models;
     #[doc(inline)]
     pub mod utils;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@
 //! # Example usage
 //! It will print the bot name when the bot is ready.
 //!
-//! ```rust
+//! ```rust,should_panic
 //! #[tokio::main]
 //! async fn main() -> Result<(), Box<dyn std::error::Error>> {
 //!


### PR DESCRIPTION
I had to write a commands system for my own bot and I thought it may be useful to others, so I wrote a new module for panda. The cornerstone of this module is the type `Command`, which is, basically, a simple callback dynamically typed but may be extended in the future with more optional data. The `Command`s created by the user are then stored in a `CommandsIndex` which is the execution context of the `Command`s. Then, a macro helps to easily create an event handler able to be passed to `Client::on_message_create`. This new API implies *no overhead* for users not using it because all the additional fields are stored outside of the `Client`, in a closure, the event handler itself.

An example is available in the module-level documentation.