### PR TITLE
Basic webhook support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ futures = "0.3.5"
 isahc = { version = "0.9.3", features = ["json"] }
 
 flate2 = { version = "1.0.14", features = ["zlib"], default-features = false }
-url = "2.1.1"
+url = { version = "2.1.1", features = ["serde"] }
 log = "0.4.8"
 
 [dependencies.tokio]

--- a/src/error.rs
+++ b/src/error.rs
@@ -76,6 +76,9 @@ pub enum PandaError {
     /// tungstenite
     TungsteniteError(TungsteniteError),
 
+    /// An invalid webhook id was given
+    InvalidWebhook,
+
     RuntimeError,
 }
 
@@ -102,6 +105,7 @@ impl fmt::Display for PandaError {
             Self::TungsteniteError(e) => write!(f, "Tungstenite Error: {}", e),
             Self::UnknownOpcodeSent => write!(f, "panda sent an invalid Opcode, please report the bug"),
             Self::InvalidDecodeSent => write!(f, "panda sent an invalid payload, please report the bug"),
+            Self::InvalidWebhook => write!(f, "invalid webhook id"),
             Self::RuntimeError => write!(f, "runtime error")
         }
     }

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -84,7 +84,7 @@ impl GatewayConnection {
             log::error!("Disconnected from the gateway, starting reconnect...");
             match GatewayConnection::new().await {
                 Ok(g) => {
-                    std::mem::replace(self, g);
+                    *self = g;
                     log::info!("Connected succesfully");
                     break;
                 }

--- a/src/http/routing.rs
+++ b/src/http/routing.rs
@@ -12,6 +12,9 @@ macro_rules! bucket_key {
     (emoji: $id: expr) => {
         format!("emoji:{}", $id.as_ref());
     };
+    (webhook: $id: expr) => {
+        format!("webhooks:{}", $id.as_ref());
+    };
 }
 
 macro_rules! api_request {
@@ -322,6 +325,20 @@ impl Route<()> {
             body: (),
         }
     }
+
+    pub(crate) fn delete_webhook(webhook_id: impl AsRef<str>) -> Self {
+        let method = Method::DELETE;
+        let uri = api_request!("/webhooks/{}", webhook_id.as_ref());
+
+        let bucket_key = bucket_key!(webhook: webhook_id);
+
+        Route {
+            method,
+            uri,
+            bucket_key,
+            body: (),
+        }
+    }
 }
 
 // Routes with body
@@ -446,6 +463,38 @@ impl<B: Into<Body>> Route<B> {
     //         body,
     //     }
     // }
+
+    pub(crate) fn create_webhook(channel_id: impl AsRef<str>, body: B) -> Self {
+        let method = Method::POST;
+        let uri = api_request!("/channels/{}/webhooks", channel_id.as_ref());
+
+        let bucket_key = bucket_key!(channel: channel_id);
+
+        Route {
+            method,
+            uri,
+            bucket_key,
+            body,
+        }
+    }
+
+    pub(crate) fn execute_webhook(
+        webhook_id: impl AsRef<str>,
+        token: impl AsRef<str>,
+        body: B
+    ) -> Self {
+        let method = Method::POST;
+        let uri = api_request!("/webhooks/{}/{}", webhook_id.as_ref(), token.as_ref());
+
+        let bucket_key = bucket_key!(webhook: webhook_id);
+
+        Route {
+            method,
+            uri,
+            bucket_key,
+            body,
+        }
+    }
 }
 
 /// Used to encode emoji as a valid char in URL

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -16,6 +16,8 @@ pub mod user;
 pub mod voice;
 #[doc(inline)]
 pub mod invite;
+#[doc(inline)]
+pub mod webhook;
 
 // Re-export all models
 pub use channel::*;
@@ -25,3 +27,4 @@ pub use guild::*;
 pub use user::*;
 pub use voice::*;
 pub use invite::*;
+pub use webhook::*;

--- a/src/models/webhook.rs
+++ b/src/models/webhook.rs
@@ -1,0 +1,48 @@
+use crate::models::user::User;
+use crate::models::channel::Embed;
+use serde::{Deserialize, Serialize};
+use serde_repr::*;
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct Webhook {
+    pub id: String,
+    #[serde(rename = "type")]
+    pub kind: WebhookKind,
+    pub guild_id: Option<String>,
+    pub channel_id: String,
+    /// The user this webhook was created by. `None` when getting a webhook by its token.
+    pub user: Option<User>,
+    pub name: Option<String>,
+    pub avatar: Option<String>,
+    /// The secure token of the webhook. Only `Some` for incoming webhooks ([`WebhookKind::Incoming`])
+    ///
+    /// [`WebhookKind::Incoming`]: enum.WebhookKind.html#variant.Incoming
+    pub token: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ExecuteWebhook {
+    #[serde(flatten)]
+    pub payload: WebhookPayload,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub username: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub avatar_url: Option<url::Url>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tts: Option<bool>,
+}
+
+#[derive(Debug, Serialize)]
+pub enum WebhookPayload {
+    #[serde(rename = "content")]
+    MessageContent(String),
+    #[serde(rename = "embeds")]
+    Embeds(Vec<Embed>),
+}
+
+#[derive(Clone, Debug, Deserialize_repr, Serialize_repr, PartialEq)]
+#[repr(u8)]
+pub enum WebhookKind {
+    Incoming = 1,
+    ChannelFollower = 2,
+}


### PR DESCRIPTION
This adds creation, execution, and deletion of webhooks. It does not support sending files to webhooks, and sending embeds is untested but it should (?) work. Creation, deletion, and execution (with message payload) has been tested and works. This PR does not include a version bump to 0.6.