### PR TITLE
FIX: handle valid ws close code defined by ws specification

### DIFF
--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -38,7 +38,7 @@ impl GatewayConnection {
         // Connect to the discord gateway through a websocket
         //let (ws, _) = connect_async(url).await.map_err(|_| PandaError::CantConnectToGateway)?;
 
-        let (ws, _) = connect_async(url).await.expect("Can't connect to gateway");
+        let (ws, _) = connect_async(url).await?;
 
         // Spawn gateway process manager
         let (to_client, mut from_gateway) = mpsc::unbounded();


### PR DESCRIPTION
The current implementation only handles library close code [defined by discord](https://discordapp.com/developers/docs/topics/opcodes-and-status-codes#gateway-gateway-close-event-codes) . 

However, sometimes we can receive a valid close code defined by websocket specification. Here is a [quick lookup](https://github.com/Luka967/websocket-close-codes) .

I encountered a 1001 close code. This is a valid case caused by unstable network connection but panda just panic, and cause my whole code to break.